### PR TITLE
Fix #47: BoolMulti always return the outcome of the last clause

### DIFF
--- a/src/test/java/org/molgenis/vcf/decisiontree/filter/BoolMultiNodeEvaluatorTest.java
+++ b/src/test/java/org/molgenis/vcf/decisiontree/filter/BoolMultiNodeEvaluatorTest.java
@@ -70,6 +70,50 @@ class BoolMultiNodeEvaluatorTest {
   }
 
   @Test
+  void evaluateClause1True() {
+    FieldImpl field1 = mock(FieldImpl.class);
+    FieldImpl field2 = mock(FieldImpl.class);
+    when(field1.getValueType()).thenReturn(ValueType.INTEGER);
+    when(field2.getValueType()).thenReturn(ValueType.INTEGER);
+
+    BoolQuery boolQueryAnd1 =
+        BoolQuery.builder().field(field1).operator(Operator.LESS).value(3).build();
+    BoolQuery boolQueryAnd2 =
+        BoolQuery.builder().field(field2).operator(Operator.GREATER).value(1).build();
+    BoolQuery boolQueryOr1 =
+        BoolQuery.builder().field(field1).operator(Operator.EQUALS).value(1).build();
+    BoolQuery boolQueryOr2 =
+        BoolQuery.builder().field(field2).operator(Operator.NOT_EQUALS).value(3).build();
+    NodeOutcome outcomeDefault = mock(NodeOutcome.class, "outcomeDefault");
+    NodeOutcome outcomeMissing = mock(NodeOutcome.class, "outcomeMissing");
+    NodeOutcome outcome1 = mock(NodeOutcome.class, "outcome1");
+    NodeOutcome outcome2 = mock(NodeOutcome.class, "outcome2");
+
+    BoolMultiQuery boolMultiQuery1 = BoolMultiQuery.builder().id("123")
+        .operator(BoolMultiQuery.Operator.AND)
+        .queryList(List.of(boolQueryAnd1, boolQueryAnd2)).outcomeTrue(outcome1).build();
+    BoolMultiQuery boolMultiQuery2 = BoolMultiQuery.builder().id("124")
+        .operator(BoolMultiQuery.Operator.OR)
+        .queryList(List.of(boolQueryOr1, boolQueryOr2)).outcomeTrue(outcome2).build();
+    List<BoolMultiQuery> clauses = List.of(boolMultiQuery1, boolMultiQuery2);
+
+    BoolMultiNode node =
+        BoolMultiNode.builder()
+            .id("bool_node")
+            .fields(List.of(field1, field2))
+            .clauses(clauses)
+            .outcomeDefault(outcomeDefault)
+            .outcomeMissing(outcomeMissing)
+            .build();
+
+    Variant variant = mock(Variant.class);
+    when(variant.getValue(field1)).thenReturn(2);
+    when(variant.getValue(field2)).thenReturn(2);
+    assertEquals(outcome1, boolMultiNodeEvaluator.evaluate(node, variant));
+  }
+
+
+  @Test
   void evaluateFalse() {
     FieldImpl field1 = mock(FieldImpl.class);
     FieldImpl field2 = mock(FieldImpl.class);


### PR DESCRIPTION
added unit test fails on the master.