### PR TITLE
Fix #53: Classification throws exception if a "standard" FORMAT field…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.molgenis</groupId>
   <artifactId>vip-decision-tree</artifactId>
-  <version>3.2.0</version>
+  <version>3.2.1</version>
 
   <name>vip-decision-tree</name>
   <description>Decision tree module for filtering and labelling VCF files</description>

--- a/src/main/java/org/molgenis/vcf/decisiontree/filter/VcfMetadata.java
+++ b/src/main/java/org/molgenis/vcf/decisiontree/filter/VcfMetadata.java
@@ -210,7 +210,7 @@ public class VcfMetadata {
     switch (fieldType) {
       case FORMAT:
         vcfCompoundHeaderLine = vcfHeader.getFormatHeaderLine(field);
-        if (vcfCompoundHeaderLine == null) {
+        if (vcfCompoundHeaderLine == null && strict) {
           throw new UnknownFieldException(field, fieldType);
         }
         break;

--- a/src/test/java/org/molgenis/vcf/decisiontree/filter/VcfMetadataTest.java
+++ b/src/test/java/org/molgenis/vcf/decisiontree/filter/VcfMetadataTest.java
@@ -280,7 +280,12 @@ class VcfMetadataTest {
 
   @Test
   void getFieldFormatUnknown() {
-    assertThrows(UnknownFieldException.class, () -> vcfMetadata.getField("FORMAT/unknown"));
+    assertEquals(new MissingField("unknown"), vcfMetadata.getField("FORMAT/unknown"));
+  }
+
+  @Test
+  void getFieldFormatUnknownStrict() {
+    assertThrows(UnknownFieldException.class, () -> vcfMetadataStrict.getField("FORMAT/unknown"));
   }
 
   @Test


### PR DESCRIPTION
… is missing